### PR TITLE
Domain in jar

### DIFF
--- a/src/opendial/DialogueSystem.java
+++ b/src/opendial/DialogueSystem.java
@@ -706,7 +706,7 @@ public class DialogueSystem {
 		if (domain.isEmpty()) {
 			return;
 		}
-		String srcFile = domain.getSourceFile().getAbsolutePath();
+		String srcFile = domain.getSourceFile().getPath();//.getAbsolutePath();
 		try {
 			domain = XMLDomainReader.extractDomain(srcFile);
 			changeSettings(domain.getSettings());

--- a/src/opendial/domains/Domain.java
+++ b/src/opendial/domains/Domain.java
@@ -32,6 +32,7 @@ import java.util.List;
 import opendial.DialogueState;
 import opendial.Settings;
 import opendial.bn.BNetwork;
+import opendial.utils.XMLUtils;
 
 /**
  * Representation of a dialogue domain, composed of (1) an initial dialogue state and
@@ -77,7 +78,9 @@ public class Domain {
 	 * @param xmlFile the file to associate
 	 */
 	public void setSourceFile(File xmlFile) {
-		if (xmlFile.exists()) {
+		if ( xmlFile.exists()
+			 || XMLUtils.existResource(xmlFile.getPath()) // file in JAR
+			) {
 			this.xmlFile = xmlFile;
 		}
 		else {
@@ -100,7 +103,9 @@ public class Domain {
 	 * @param xmlFile the file to add
 	 */
 	public void addImportedFiles(File xmlFile) {
-		if (xmlFile.exists()) {
+		if ( xmlFile.exists()
+			 || XMLUtils.existResource(xmlFile.getPath()) // file in JAR
+			) {
 			importedFiles.add(xmlFile);
 		}
 		else {

--- a/src/opendial/gui/EditorTab.java
+++ b/src/opendial/gui/EditorTab.java
@@ -197,7 +197,7 @@ public class EditorTab extends JComponent {
 	protected void rereadFile() {
 		try {
 			editor.read(
-					new InputStreamReader(XMLUtils.getXMLDocumentStream(shownFile.getPath())) // throw RuntimeException
+					new InputStreamReader(XMLUtils.getXMLDocumentStream(shownFile.getPath()), XMLUtils.XML_CHARSET) // throw RuntimeException
 					, shownFile);
 
 			// Set the font style (default 13).

--- a/src/opendial/gui/EditorTab.java
+++ b/src/opendial/gui/EditorTab.java
@@ -30,8 +30,8 @@ import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -66,6 +66,7 @@ import net.java.balloontip.styles.BalloonTipStyle;
 import net.java.balloontip.styles.RoundedBalloonStyle;
 import opendial.domains.Domain;
 import opendial.gui.utils.DomainEditorKit;
+import opendial.utils.XMLUtils;
 
 public class EditorTab extends JComponent {
 
@@ -195,7 +196,9 @@ public class EditorTab extends JComponent {
 	 */
 	protected void rereadFile() {
 		try {
-			editor.read(new FileReader(shownFile), shownFile);
+			editor.read(
+					new InputStreamReader(XMLUtils.getXMLDocumentStream(shownFile.getPath())) // throw RuntimeException
+					, shownFile);
 
 			// Set the font style (default 13).
 			editor.setFont(new Font("Verdana", Font.PLAIN, 13));
@@ -212,7 +215,9 @@ public class EditorTab extends JComponent {
 			editor.requestFocusInWindow();
 
 		}
-		catch (IOException e) {
+		catch (RuntimeException e) {
+			log.severe("cannot open xml file: " + e);
+		} catch (IOException e) {
 			log.severe("cannot read xml file: " + e);
 		}
 	}

--- a/src/opendial/gui/GUIFrame.java
+++ b/src/opendial/gui/GUIFrame.java
@@ -446,7 +446,7 @@ public class GUIFrame implements Module {
 
 		try {
 			String skeletton = "<domain>\n\n</domain>";
-			Files.write(Paths.get(fileToSave.toURI()), skeletton.getBytes());
+			Files.write(Paths.get(fileToSave.toURI()), skeletton.getBytes(XMLUtils.XML_CHARSET));
 			log.info("Saving domain in " + fileToSave);
 			Domain newDomain =
 					XMLDomainReader.extractDomain(fileToSave.getAbsolutePath());
@@ -524,7 +524,7 @@ public class GUIFrame implements Module {
 		String curText = editorTab.getText();
 		if (fileToWrite != null) {
 			try {
-				Files.write(Paths.get(fileToWrite.toURI()), curText.getBytes());
+				Files.write(Paths.get(fileToWrite.toURI()), curText.getBytes(XMLUtils.XML_CHARSET));
 			}
 			catch (IOException e) {
 				log.severe("Cannot save domain: " + e);

--- a/src/opendial/gui/GUIFrame.java
+++ b/src/opendial/gui/GUIFrame.java
@@ -117,7 +117,8 @@ public class GUIFrame implements Module {
 				else {
 					frame.setIconImage(
 							ImageIO.read(GUIFrame.class.getResourceAsStream(
-									"/" + ICON_PATH.replace("//", "/"))));
+									"/" + ICON_PATH.replace("//", "/").replace('\\', '/')
+									)));
 				}
 			}
 			catch (Exception e) {

--- a/src/opendial/modules/RemoteConnector.java
+++ b/src/opendial/modules/RemoteConnector.java
@@ -175,7 +175,7 @@ public class RemoteConnector implements Module {
 			// socket
 			if (root.hasChildNodes()) {
 				InputStream content = new ByteArrayInputStream(
-						XMLUtils.serialise(xmlDoc).getBytes());
+						XMLUtils.serialise(xmlDoc).getBytes(XMLUtils.XML_CHARSET));
 				forwardContent(MessageType.XML, content);
 				return;
 			}
@@ -322,7 +322,7 @@ public class RemoteConnector implements Module {
 					}
 				}
 				else if (type == MessageType.XML) {
-					String content = new String(message);
+					String content = new String(message, XMLUtils.XML_CHARSET);
 					Document doc = XMLUtils.loadXMLFromString(content);
 					BNetwork nodes = XMLStateReader
 							.getBayesianNetwork(XMLUtils.getMainNode(doc));

--- a/src/opendial/utils/XMLUtils.java
+++ b/src/opendial/utils/XMLUtils.java
@@ -95,10 +95,11 @@ public class XMLUtils {
 			}
 		}
 		else {
+			String resource = "/"+filename.replace("//", "/").replace('\\', '/');
 			is = XMLUtils.class
-					.getResourceAsStream("/" + filename.replace("//", "/"));
+					.getResourceAsStream(resource);
 			if (is == null) {
-				throw new RuntimeException("Resource cannot be found: " + filename);
+				throw new RuntimeException("Resource cannot be found: "+resource+" ("+ filename+")");
 			}
 		}
 

--- a/src/opendial/utils/XMLUtils.java
+++ b/src/opendial/utils/XMLUtils.java
@@ -32,6 +32,8 @@ import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
@@ -77,6 +79,8 @@ public class XMLUtils {
 
 	// logger
 	final static Logger log = Logger.getLogger("OpenDial");
+	
+	public static Charset XML_CHARSET = StandardCharsets.UTF_8;
 
 	/**
 	 * Opens the XML document stream.
@@ -119,7 +123,7 @@ public class XMLUtils {
 	public static Document getXMLDocument(String filename) {
 		InputStream is = getXMLDocumentStream(filename);
 
-		return getXMLDocument(new InputSource(new InputStreamReader(is))); //TODO: set encoding
+		return getXMLDocument(new InputSource(new InputStreamReader(is, XML_CHARSET)));
 	}
 	
 	public static String toResourcePath(String filename) {

--- a/src/opendial/utils/XMLUtils.java
+++ b/src/opendial/utils/XMLUtils.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.net.URL;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
@@ -95,7 +96,7 @@ public class XMLUtils {
 			}
 		}
 		else {
-			String resource = "/"+filename.replace("//", "/").replace('\\', '/');
+			String resource = toResourcePath(filename);
 			is = XMLUtils.class
 					.getResourceAsStream(resource);
 			if (is == null) {
@@ -105,6 +106,22 @@ public class XMLUtils {
 
 		return getXMLDocument(new InputSource(new InputStreamReader(is)));
 	}
+	
+	public static String toResourcePath(String filename) {
+			String resource = "/"	// prepend '/' to be an 'absolute' path (i.e. not relative to XMLUtils.class package)
+					+ filename	
+					  .replace("//", "/")	// some resources have the // sequence 
+					  .replace('\\', '/')	// transform windows path into /-path
+					 ;
+			return resource;
+	}
+	
+	public static boolean existResource(String filename) {
+		URL url = XMLUtils.class
+				.getResource(toResourcePath(filename));
+		return url!=null;
+	}
+	
 
 	/**
 	 * Opens the XML document referenced by the input source, and returns it

--- a/src/opendial/utils/XMLUtils.java
+++ b/src/opendial/utils/XMLUtils.java
@@ -79,12 +79,16 @@ public class XMLUtils {
 	final static Logger log = Logger.getLogger("OpenDial");
 
 	/**
-	 * Opens the XML document referenced by the filename, and returns it
+	 * Opens the XML document stream.
+	 * 
+	 * The XML document could be a real file
+	 *  or a resource in the JAR file. 
 	 * 
 	 * @param filename the filename
 	 * @return the XML document
+	 * @throws RuntimeException if neither the file nor the resource could be found
 	 */
-	public static Document getXMLDocument(String filename) {
+	public static InputStream getXMLDocumentStream(String filename) {
 		InputStream is = null;
 		if (new File(filename).exists()) {
 			try {
@@ -103,8 +107,19 @@ public class XMLUtils {
 				throw new RuntimeException("Resource cannot be found: "+resource+" ("+ filename+")");
 			}
 		}
+		return is;
+	}
 
-		return getXMLDocument(new InputSource(new InputStreamReader(is)));
+	/**
+	 * Opens the XML document referenced by the filename, and returns it
+	 * 
+	 * @param filename the filename
+	 * @return the XML document
+	 */
+	public static Document getXMLDocument(String filename) {
+		InputStream is = getXMLDocumentStream(filename);
+
+		return getXMLDocument(new InputSource(new InputStreamReader(is))); //TODO: set encoding
 	}
 	
 	public static String toResourcePath(String filename) {
@@ -121,6 +136,8 @@ public class XMLUtils {
 				.getResource(toResourcePath(filename));
 		return url!=null;
 	}
+	
+	
 	
 
 	/**


### PR DESCRIPTION
Dear Pierre,

We start to use OpenDial in a project as it seems enough flexible to quickly start and progressively improve the dialog system. You make a very good job !

For distribution purpose I included a multi-files[1] domain definition into a JAR and ran into some problems (mainly on Windows) that I tried to resolved with this branch.

Last commit (5a0b2f2) go a little further, defining the domain's XML charset to UTF-8 (so it become possible to not have to set the 'file.encoding' system property before running OpenDial, but I have just done quick tests).

Best regards,

Grégoire Montcheuil

[1] i.e. a domain file with various `<import href="relative/path/to/domain-chunk.xml" />`