### PR TITLE
Set java.awt.headless to avoid locking on tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ test {
 		exceptionFormat = 'full'
     }
   	systemProperty 'file.encoding', 'UTF-8'
+  	systemProperty 'java.awt.headless', 'true'
 }
 
 /**


### PR DESCRIPTION
When running on a non-headless JDK, an AWT window opens and the system
locks (on Debian Strech, OpenJDK 8).

This patch ensures the default tests are headless (the test files
compile and are available to be run separately as needed).