### PR TITLE
Fixed Swing thread race condition

### DIFF
--- a/src/opendial/gui/GUIFrame.java
+++ b/src/opendial/gui/GUIFrame.java
@@ -42,6 +42,7 @@ import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.JTabbedPane;
+import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 import javax.swing.filechooser.FileNameExtensionFilter;
 
@@ -185,10 +186,11 @@ public class GUIFrame implements Module {
 	 */
 	@Override
 	public void trigger(DialogueState state, Collection<String> updatedVars) {
-		if (frame != null && frame.isVisible()) {
+		if (frame != null && frame.isVisible()) 
+		  SwingUtilities.invokeLater( () -> {
 			chatTab.trigger(state, updatedVars);
 			stateMonitorTab.refresh(state, updatedVars);
-		}
+		});
 		refresh();
 	}
 


### PR DESCRIPTION
When submitting input, the system is updated in a separate thread, which
in turns issues a UI update. However, if the separate threads execute
very fast, the UI thread is still blocked updating the input submission
and everything blocks.

In general, the UI update should only be done from the Swing thread,
which can be performed using the SwingUtilities.invokeLater method,
as in this path.

Tested on

openjdk version "1.8.0_111"
OpenJDK Runtime Environment (build 1.8.0_111-8u111-b14-3-b14)
OpenJDK 64-Bit Server VM (build 25.111-b14, mixed mode)